### PR TITLE
Fix:Remove 2019 from translation

### DIFF
--- a/homepage.yml
+++ b/homepage.yml
@@ -18,7 +18,7 @@ translations:
     t: 參加調查
 
   - key: homepage.view_results
-    t: 看 2019 年的結果
+    t: 看調查結果
 
   - key: share.help_spread
     t: 幫忙宣傳！


### PR DESCRIPTION
將原有翻譯內的 2019 移除，這樣感覺比較不會讓閱讀者產生疑惑。

